### PR TITLE
Exit with code 1 on build error

### DIFF
--- a/build.js
+++ b/build.js
@@ -83,4 +83,8 @@ compiler.run((err, stats) => {
     modules: false,
     chunks: false
   }));
+
+  if (stats.hasErrors()) {
+    process.exit(1);
+  }
 });


### PR DESCRIPTION
This change should prevent the build from failing unnoticed.