### PR TITLE
Replace `lodash` with `lodash-es`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3245,7 +3245,13 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "node build.js"
   },
   "dependencies": {
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "vue": "^2.6.12",
     "vue-i18n": "^8.24.2",
     "vue-router": "^3.5.1"

--- a/src/components/ASFConfig.vue
+++ b/src/components/ASFConfig.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script>
-  import { each } from 'lodash';
+  import { each } from 'lodash-es';
   import Config from './mixin/Config.vue';
 
   export default {

--- a/src/components/BotConfig.vue
+++ b/src/components/BotConfig.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script>
-  import { each } from 'lodash';
+  import { each } from 'lodash-es';
   import Config from './mixin/Config.vue';
 
   export default {

--- a/src/components/fields/InputMap.vue
+++ b/src/components/fields/InputMap.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script>
-  import { each } from 'lodash';
+  import { each } from 'lodash-es';
   import Input from '../mixin/Input.vue';
 
   export default {

--- a/src/components/fields/InputSet.vue
+++ b/src/components/fields/InputSet.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script>
-  import { each } from 'lodash';
+  import { each } from 'lodash-es';
   import Input from '../mixin/Input.vue';
 
   export default {

--- a/src/components/mixin/Config.vue
+++ b/src/components/mixin/Config.vue
@@ -1,5 +1,5 @@
 <script>
-  import { each } from 'lodash';
+  import { each } from 'lodash-es';
 
   import schema from '../../schema';
 

--- a/src/validators.js
+++ b/src/validators.js
@@ -1,4 +1,4 @@
-import { isArray, isNil, isNumber, isString } from 'lodash';
+import { isArray, isNil, isNumber, isString } from 'lodash-es';
 
 function checkEmpty(value, required) {
     if (isNil(value) || value === '') {


### PR DESCRIPTION
`lodash-es` is better suited for web applications, as it allows for tree-shaking

We should replace `lodash-es` with helper functions, as it is still quite heavy due to strict runtime type checking and function overloads.