### PR TITLE
Wrong workflow badge route at readme

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -2,7 +2,7 @@
 
 Standalone web config generator for ASF
 
-[![Build status (GitHub)](https://img.shields.io/github/workflow/status/JustArchiNET/ASF-WebConfigGenerator/ASF-WebConfigGenerator-CI/main?label=GitHub&maxAge=600)](https://github.com/JustArchiNET/ASF-WebConfigGenerator/actions?query=branch%3Amain)
+[![Build status (GitHub)](https://img.shields.io/github/actions/workflow/status/JustArchiNET/ASF-WebConfigGenerator/ci.yml?branch=main&label=GitHub&maxAge=600)](https://github.com/JustArchiNET/ASF-WebConfigGenerator/actions?query=branch%3Amain)
 [![Github last commit date](https://img.shields.io/github/last-commit/JustArchiNET/ASF-WebConfigGenerator?label=Updated&maxAge=600)](https://github.com/JustArchiNET/ASF-WebConfigGenerator/commits)
 [![License](https://img.shields.io/github/license/JustArchiNET/ASF-WebConfigGenerator?label=License&maxAge=2592000)](https://github.com/JustArchiNET/ASF-WebConfigGenerator/blob/main/LICENSE.txt)
 


### PR DESCRIPTION
Looks like shields changed at some point the route for workflow badges. Refers to https://github.com/badges/shields/issues/8671
This repo is still using old route as a result README.md is not able to display current CI/CD status, see below:

![image](https://github.com/JustArchiNET/ASF-WebConfigGenerator/assets/1280022/97ecb37f-58fc-4451-b830-ee9872bc4ef6)

This PR simply fix that.
Kind Regards
